### PR TITLE
Changed "save" and "get" logic on server side

### DIFF
--- a/esx_accessories.sql
+++ b/esx_accessories.sql
@@ -1,6 +1,0 @@
-INSERT INTO `datastore` (name, label, shared) VALUES
-	('user_ears', 'Ears', 0),
-	('user_glasses', 'Glasses', 0),
-	('user_helmet', 'Helmet', 0),
-	('user_mask', 'Mask', 0)
-;

--- a/server/main.lua
+++ b/server/main.lua
@@ -8,32 +8,42 @@ end)
 
 RegisterServerEvent('esx_accessories:save')
 AddEventHandler('esx_accessories:save', function(skin, accessory)
-	local source = source
-	local xPlayer = ESX.GetPlayerFromId(source)
+    local _source = source
+    local xPlayer = ESX.GetPlayerFromId(_source)
 
-	TriggerEvent('esx_datastore:getDataStore', 'user_' .. string.lower(accessory), xPlayer.identifier, function(store)
-		store.set('has' .. accessory, true)
+    TriggerEvent('esx_datastore:getDataStore', 'property', xPlayer.identifier, function(store)
+        local accessories = store.get('accessories')
 
-		local itemSkin = {}
-		local item1 = string.lower(accessory) .. '_1'
-		local item2 = string.lower(accessory) .. '_2'
-		itemSkin[item1] = skin[item1]
-		itemSkin[item2] = skin[item2]
+        if accessories == nil then
+            accessories = {}
+        end
 
-		store.set('skin', itemSkin)
-	end)
+        local itemSkin = {}
+        local item1 = string.lower(accessory) .. '_1'
+        local item2 = string.lower(accessory) .. '_2'
+        itemSkin[item1] = skin[item1]
+        itemSkin[item2] = skin[item2]
+
+        accessories[string.lower(accessory)] = itemSkin
+        store.set('accessories', accessories)
+    end)
 end)
 
 ESX.RegisterServerCallback('esx_accessories:get', function(source, cb, accessory)
-	local xPlayer = ESX.GetPlayerFromId(source)
+    local xPlayer = ESX.GetPlayerFromId(source)
 
-	TriggerEvent('esx_datastore:getDataStore', 'user_' .. string.lower(accessory), xPlayer.identifier, function(store)
-		local hasAccessory = (store.get('has' .. accessory) and store.get('has' .. accessory) or false)
-		local skin = (store.get('skin') and store.get('skin') or {})
+    TriggerEvent('esx_datastore:getDataStore', 'property', xPlayer.identifier, function(store)
+        local accessories = store.get('accessories')
+        if accessories == nil then
+            accessories = {}
+        end
 
-		cb(hasAccessory, skin)
-	end)
+        local accessoryData = accessories[string.lower(accessory)]
+        local hasAccessory = accessoryData ~= nil
+        local skin = accessoryData or {}
 
+        cb(hasAccessory, skin)
+    end)
 end)
 
 ESX.RegisterServerCallback('esx_accessories:checkMoney', function(source, cb)


### PR DESCRIPTION
These changes won't create separate rows for each accessory, instead fetching the accessories from the player's property dressing row, so the `datastore_data` will have less rows in the end thanks to metadata.